### PR TITLE
fix: re-wrap bytes data to normalize capacity

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -25,13 +25,18 @@ func From(cnt uint32, rnd1 uint64, rnd2 uint64, ts int64) UUID {
 }
 
 func Parse(uuid string) (UUID, error) {
+	const uuidLen = 36
 	var u UUID
 
-	s := *(*[]byte)(unsafe.Pointer(&uuid))
-
-	if len(s) != 36 {
+	bytesPtr := *(*[]byte)(unsafe.Pointer(&uuid))
+	if uuidLen != len(bytesPtr) {
 		return u, ErrBadUUID
 	}
+	s := *(*[]byte)(unsafe.Pointer(&struct {
+		data uintptr
+		len  int
+		cap  int
+	}{uintptr(unsafe.Pointer(&bytesPtr[0])), uuidLen, uuidLen}))
 
 	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
 		return u, ErrBadUUID


### PR DESCRIPTION
## The problem: 

Direct unsafe casting of `uuid string` to `s []bytes` causing out of bounds panic, due to `cap(s) == 0`, in specific compilation flags combinations. 
For me, it was doing an "unoptimized compilation", you can check out the initial issue [here](https://github.com/go-delve/delve/issues/3563).

### The proposed fix:

Re-wrapping the raw bytes with newly crafted metadata that respects slice capacity and keeps the runtime bounds check happy.

### Debug printout stating 0 cap:
![Debug printout stating 0 cap](https://github.com/GoWebProd/uuid7/assets/239034/3a713d34-8a5d-4193-9032-245a8f0f29de)

### Actual panicking line:
![Actual panicking line:](https://github.com/GoWebProd/uuid7/assets/239034/78d36465-4482-4767-be1a-dede59618027)

### Test pass
```
$ go test ./... -race
ok      github.com/GoWebProd/uuid7      1.011s
```

